### PR TITLE
Fix distinct queries

### DIFF
--- a/models/weblog.php
+++ b/models/weblog.php
@@ -111,14 +111,14 @@
 		 */
 		public function get_years() {
 			$query = "select distinct year(timestamp) as year from weblogs ".
-			         "where visible=%d order by timestamp desc";
+			         "where visible=%d order by year desc";
 
 			return $this->db->execute($query, YES);
 		}
 
 		public function get_periods() {
 			$query = "select distinct month(timestamp) as month, year(timestamp) as year from weblogs ".
-			         "where visible=%d order by timestamp desc";
+			         "where visible=%d order by year, month desc";
 
 			return $this->db->execute($query, YES);
 		}


### PR DESCRIPTION
As of MySQL v5.7.5 they changed the default SQL mode to include ONLY_FULL_GROUP_BY.

This means that a query with fields in the ORDER BY clause also need to have those fields in the SELECT statement when they are grouped by DISTINCT.