### PR TITLE
Error checking to see if $message is null

### DIFF
--- a/libraries/protocols/email.php
+++ b/libraries/protocols/email.php
@@ -365,7 +365,7 @@
 				return false;
 			}
 
-			if (count($this->message) === null) {
+			if (empty($this->message)) {
 				$this->message("");
 			}
 


### PR DESCRIPTION
Getting the following error:

count(): Parameter must be an array or an object that implements Countable
line 368 in /var/www/banshee63/libraries/protocols/email.php

Using empty() will return true if any of the following conditions are met:

> variable is an empty string, false, array(), NULL, “0?, 0, and an unset variable.